### PR TITLE
Use environment variable for API domain

### DIFF
--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,2 @@
+# Domain
+DOMAIN=http://localhost:5000/

--- a/frontend/src/helpers/apis.js
+++ b/frontend/src/helpers/apis.js
@@ -1,11 +1,11 @@
 export const predict = body =>
-  fetch('/test/api/predict', {
+  fetch(`${process.env.DOMAIN || ''}/test/api/predict`, {
     method: 'POST',
     body,
   }).then(async res => (await res.json()).id);
 
 export const getPrediction = body =>
-  fetch('/test/api/job', {
+  fetch(`${process.env.DOMAIN || ''}/test/api/job`, {
     method: 'POST',
     body,
   }).then(res => res.json());


### PR DESCRIPTION
Set the environment variable `DOMAIN` (on the system, via .env.production, etc.). Make sure to include `http://` or `https://` so it's not considered a relative url.