### PR TITLE
Fix issue with environment variable not loading

### DIFF
--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,2 +1,2 @@
 # Domain
-DOMAIN=http://localhost:5000/
+REACT_APP_DOMAIN=http://localhost:5000/

--- a/frontend/src/helpers/apis.js
+++ b/frontend/src/helpers/apis.js
@@ -1,11 +1,11 @@
 export const predict = body =>
-  fetch(`${process.env.DOMAIN || ''}/test/api/predict`, {
+  fetch(`${process.env.REACT_APP_DOMAIN || ''}/test/api/predict`, {
     method: 'POST',
     body,
   }).then(async res => (await res.json()).id);
 
 export const getPrediction = body =>
-  fetch(`${process.env.DOMAIN || ''}/test/api/job`, {
+  fetch(`${process.env.REACT_APP_DOMAIN || ''}/test/api/job`, {
     method: 'POST',
     body,
   }).then(res => res.json());


### PR DESCRIPTION
Since we're building with CRA, they enforce naming all environment variables with a prefix REACT_APP_ to ensure not all environment variables get injected.