### PR TITLE
Fix issue with using the same src string for cropping and displayed prediction

### DIFF
--- a/frontend/src/components/ASLDetector2.jsx
+++ b/frontend/src/components/ASLDetector2.jsx
@@ -155,7 +155,7 @@ export default class ASLDetector2 extends Component<Props, State> {
     this.setState({
       errorMessage: '',
       showWebcam: false,
-      src: imgSrc,
+      uploadSrc: imgSrc,
       showCrop: true,
     });
     // console.log(imgSrc);

--- a/frontend/src/components/ASLDetector2.jsx
+++ b/frontend/src/components/ASLDetector2.jsx
@@ -81,7 +81,6 @@ export default class ASLDetector2 extends Component<Props, State> {
 
   sendFile = async (file: Blob) => {
     this.setState({ disabled: true });
-    console.log(file);
     const formData = new FormData();
     formData.append('file_to_upload', new File([file], 'image.jpeg'));
     let id;
@@ -106,7 +105,6 @@ export default class ASLDetector2 extends Component<Props, State> {
     let predictionData;
     while (!found && prevId === id) {
       await wait();
-      console.log('waiting...');
       try {
         data = await getPrediction(idForm);
       } catch (err) {
@@ -125,7 +123,6 @@ export default class ASLDetector2 extends Component<Props, State> {
     }
 
     const result = getAlphabet(predictionData);
-    console.log(result);
 
     this.setState({
       prediction: result,
@@ -158,8 +155,6 @@ export default class ASLDetector2 extends Component<Props, State> {
       uploadSrc: imgSrc,
       showCrop: true,
     });
-    // console.log(imgSrc);
-    // await this.sendFile(dataURLToBlob(imgSrc));
   };
 
   closeCrop = () => {

--- a/frontend/src/components/ASLDetector2.jsx
+++ b/frontend/src/components/ASLDetector2.jsx
@@ -30,11 +30,13 @@ type State = {|
   src: ?string,
   showWebcam: boolean,
   showCrop: boolean,
+  uploadSrc: ?string,
 |};
 
 const resetState = Object.freeze({
   disabled: false,
   errorMessage: '',
+  uploadSrc: null,
 });
 
 let prevId: ?string = null;
@@ -72,7 +74,7 @@ export default class ASLDetector2 extends Component<Props, State> {
     const [file: File] = acceptedFiles;
     this.setState({
       errorMessage: '',
-      src: URL.createObjectURL(file),
+      uploadSrc: URL.createObjectURL(file),
       showCrop: true,
     });
   };
@@ -203,7 +205,7 @@ export default class ASLDetector2 extends Component<Props, State> {
           isOpen={this.state.showCrop}
           onClose={this.closeCrop}
           onConfirm={this.confirmCrop}
-          src={this.state.src}
+          src={this.state.uploadSrc}
         />
         <WebcamModal
           isOpen={this.state.showWebcam}


### PR DESCRIPTION
Once an image is uploaded, it gets sent to the crop phase. The currently displayed picture for the prediction should not be changed until after the result comes through.